### PR TITLE
Fix MPS issue with lack of f64 support

### DIFF
--- a/latent_space_explorer/sampling.py
+++ b/latent_space_explorer/sampling.py
@@ -18,7 +18,10 @@ class EncodingSampler:
         """
         device = recursive_find_device(self.encodes)
         dtype = recursive_find_dtype(self.encodes)
-        coefs = torch.from_numpy(coefs).to(device).to(dtype)
+        # NOTE: Convert from float64 first to `dtype` and *then* to `device` to
+        # prevent issues with certain devices not supporting f64
+        # (*cough cough* Apple)
+        coefs = torch.from_numpy(coefs).to(dtype).to(device)
 
         def single_apply(encodes):
             if encodes is None:


### PR DESCRIPTION
Hey, I've got an M1 macbook and pytorch was complaining about not being able to convert to f64, but everything was in f16 as far as I could see. Turns out this one line was causing the problem, and converting the f64s to f16s before sending it to the M1 chip (instead of trying to send f64s to the M1) worked perfectly.